### PR TITLE
Add tzinfo-data on Windows

### DIFF
--- a/Gemfile.tt
+++ b/Gemfile.tt
@@ -22,6 +22,8 @@ gem 'rails-i18n'
 gem 'sidekiq'
 gem 'sidekiq-failures'
 
+gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
+
 gem 'friendly_id'
 
 group :development, :test do


### PR DESCRIPTION
Windows does not ship with timezone information, meaning that the installation errors. This PR adds the `tzinfo-data` gem to the default Gemfile to address this error.